### PR TITLE
Try antialiased widgets

### DIFF
--- a/src/blue_and_pink_synth_editor/blueandpinksyntheditor.kv
+++ b/src/blue_and_pink_synth_editor/blueandpinksyntheditor.kv
@@ -14,7 +14,7 @@ ScreenManager:
     canvas.before:
         Color:
             rgba: C('#092042FF')
-        Rectangle:
+        SmoothRectangle:
             pos: self.pos
             pos: self.pos
             size: self.size
@@ -47,7 +47,7 @@ ScreenManager:
     canvas.before:
         Color:
             rgba: C('#092042FF')
-        Rectangle:
+        SmoothRectangle:
             pos: self.pos
             size: self.size
 
@@ -102,7 +102,7 @@ ScreenManager:
     canvas.before:
         Color:
             rgba: C('#092042FF')
-        Rectangle:
+        SmoothRectangle:
             pos: self.pos
             size: self.size
 
@@ -877,7 +877,7 @@ ScreenManager:
 #    canvas.before:
 #        Color:
 #            rgba: C('#0000FFFF')
-#        Rectangle:
+#        SmoothRectangle:
 #            pos: self.pos
 #            size: self.size
 
@@ -893,7 +893,7 @@ ScreenManager:
 #        canvas.before:
 #            Color:
 #                rgba: C('#00FFFFFF')
-#            Rectangle:
+#            SmoothRectangle:
 #                pos: self.pos
 #                size: self.size
 
@@ -934,7 +934,7 @@ ScreenManager:
 #    canvas.before:
 #        Color:
 #            rgba: C('#F000F0FF')
-#        Rectangle:
+#        SmoothRectangle:
 #            pos: self.pos
 #            size: self.size
 
@@ -969,7 +969,7 @@ ScreenManager:
 #    canvas.before:
 #        Color:
 #            rgba: C('#F000F0FF')
-#        Rectangle:
+#        SmoothRectangle:
 #            pos: self.pos
 #            size: self.size
 

--- a/src/blue_and_pink_synth_editor/blueandpinksyntheditor.kv
+++ b/src/blue_and_pink_synth_editor/blueandpinksyntheditor.kv
@@ -137,7 +137,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [0, 0, root.corner_radius, root.corner_radius]
@@ -270,7 +270,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -332,7 +332,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -393,7 +393,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -454,7 +454,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -516,7 +516,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -577,7 +577,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -638,7 +638,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -699,7 +699,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -764,7 +764,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [0, 0, root.corner_radius, root.corner_radius]
@@ -792,7 +792,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [0, 0, root.corner_radius, root.corner_radius]
@@ -1004,7 +1004,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -1054,7 +1054,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -1079,7 +1079,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -1107,7 +1107,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -1134,7 +1134,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -1187,7 +1187,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -1326,7 +1326,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -1465,7 +1465,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -1538,7 +1538,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -1611,7 +1611,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -1678,7 +1678,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -1760,7 +1760,7 @@ ScreenManager:
     canvas.before:
         Color:
             rgba: C(self.background_color_string)
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             size: self.size
             pos: self.pos
             radius: [root.corner_radius]
@@ -1833,7 +1833,7 @@ ScreenManager:
         Color:
             rgba: C(self.background_color_string)
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: self.pos
             size: self.size
             radius: [self.width * 0.5]
@@ -1842,7 +1842,7 @@ ScreenManager:
         Color:
             rgba: C(root.color_hex) if root.midi_val > 0 else C('#00000000')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: self.pos
             size: self.size[0], (root.midi_val / 127.0) * (root.height - root.height * 0.01)
             radius: [self.width * 0.5]
@@ -1875,7 +1875,7 @@ ScreenManager:
     canvas.before:
         Color:
             rgba: C(self.background_color_string)
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             size: self.size
             pos: self.pos
             radius: [root.corner_radius]
@@ -1913,7 +1913,7 @@ ScreenManager:
     canvas.before:
         Color:
             rgba: C(self.background_color_string)
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             size: self.size
             pos: self.pos
             radius: [root.corner_radius]
@@ -2082,7 +2082,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -2151,7 +2151,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -2177,7 +2177,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -2202,7 +2202,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius]
@@ -2328,7 +2328,7 @@ ScreenManager:
         Color:
             rgba: C('#257CFFFF')
 
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             pos: root.pos
             size: root.width, root.height
             radius: [root.corner_radius, root.corner_radius, root.corner_radius, root.corner_radius]
@@ -2417,7 +2417,7 @@ ScreenManager:
     canvas.before:
         Color:
             rgba: C(self.background_color_string)
-        RoundedRectangle:
+        SmoothRoundedRectangle:
             size: self.size
             pos: self.pos
             radius: [root.corner_radius]


### PR DESCRIPTION
Discovered the new antialiased versions of kivy widgets RoundedRectangle and Rectangle. Switched to them. There definitely is a visible difference with SmoothRoundedRectangle. I assume there would also be a difference with SmoothRectangle if I was using Rectangle differently.